### PR TITLE
FIx for issue #213

### DIFF
--- a/kansa.ps1
+++ b/kansa.ps1
@@ -502,14 +502,15 @@ Param(
     # Need to maintain the order for "order of volatility"
     $ModuleHash = New-Object System.Collections.Specialized.OrderedDictionary
 
-    if (!(ls $ModuleScript | Select-Object -ExpandProperty PSIsContainer)) {
-        # User may have provided full path to a .ps1 module, which is how you run a single module explicitly
-        $ModuleHash.Add((ls $ModuleScript), $ModuleArgs)
+    if (Test-Path($ModuleScript)) {
+    	if (!(ls $ModuleScript | Select-Object -ExpandProperty PSIsContainer)) {
+        	# User may have provided full path to a .ps1 module, which is how you run a single module explicitly
+        	$ModuleHash.Add((ls $ModuleScript), $ModuleArgs)
 
-        if (Test-Path($ModuleScript)) {
-            $Module = ls $ModuleScript | Select-Object -ExpandProperty BaseName
-            Write-Verbose "Running module: `n$Module $ModuleArgs"
-            Return $ModuleHash
+        
+            	$Module = ls $ModuleScript | Select-Object -ExpandProperty BaseName
+           	Write-Verbose "Running module: `n$Module $ModuleArgs"
+            	Return $ModuleHash
         }
     }
     $ModConf = $ModulePath + "\" + "Modules.conf"


### PR DESCRIPTION
Get-Modules fails at line 506 due to split operation on line 498 if a directory path contains a space character. Simple fix to wrap if(!(ls $ModuleScript) with a pre-existing Test-Path on line 509 to check whether path is valid