### PR TITLE
Update Get-Targets.ps1 access $tgt variable rather than $tgt.Name attribute

### DIFF
--- a/Get-Targets.ps1
+++ b/Get-Targets.ps1
@@ -24,9 +24,10 @@ if($LastLogonLessThanDaysAgo -gt 0){
 
 $real_targets = New-Object System.Collections.ArrayList
 
+#MR edit - $tgt.Name changed to $tgt as Name does not appear to valid attribute from my own testing and this loop results in an empty array
 foreach ($tgt in $targets){
     if ($tgt.Name -match $HostnameRegex){
-        [void]$real_targets.Add($tgt.Name)
+        [void]$real_targets.Add($tgt)
     }
 }
 


### PR DESCRIPTION
Fixes an issue identified where the operation on line 29 results in an empty array being produced