### PR TITLE
Increase job timeout default

### DIFF
--- a/kansa.ps1
+++ b/kansa.ps1
@@ -374,7 +374,7 @@ Param(
     [Parameter(Mandatory=$false,Position=21)]
         [String[]]$ElkAlert=@(),
     [Parameter(Mandatory=$false,Position=22)]
-        [int32]$JobTimeout=600,
+        [int32]$JobTimeout=900,
     [Parameter(Mandatory=$false,Position=23)]
         [uint16[]]$ElkPort=@(1337),
     [Parameter(Mandatory=$false,Position=24)]


### PR DESCRIPTION
My testing has identified that $jobtimeout is too low to allow Get-FileHashes.ps1 to complete, increased default value from 600seconds to 900seconds